### PR TITLE
Add support for custom propulsion-engine SFC curves

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ cetos provides tools for analyzing vessel performance, estimating fuel consumpti
 ### Features
 
 - **Fuel Consumption Estimation**: Calculate vessel fuel consumption based on IMO methodologies
+- **Custom SFC Curves**: Override the IMO fuel model with your own measured engine SFC curve
 - **Energy System Analysis**: Analyze batteries, hydrogen systems, and hybrid propulsion
 - **AIS Data Processing**: Convert AIS data to voyage profiles
 - **Multiple Vessel Types**: Support for various vessel types (ferries, container ships, tankers, etc.)
@@ -52,10 +53,10 @@ vessel_data = VesselData(
 voyage_profile = VoyageProfile(
     time_anchored_h=10.0,
     time_at_berth_h=10.0,
-    legs_manoeuvring=[VoyageLeg(distance_nm=10, speed_kn=10, draft_m=6)],
+    legs_manoeuvring=[VoyageLeg(distance_nm=10, speed_kn=10, draft_m=2.8)],
     legs_at_sea=[
-        VoyageLeg(distance_nm=30, speed_kn=10, draft_m=6),
-        VoyageLeg(distance_nm=30, speed_kn=10, draft_m=6),
+        VoyageLeg(distance_nm=30, speed_kn=10, draft_m=2.8),
+        VoyageLeg(distance_nm=30, speed_kn=10, draft_m=2.8),
     ],
 )
 
@@ -63,6 +64,37 @@ voyage_profile = VoyageProfile(
 results = imo.estimate_fuel_consumption(vessel_data, voyage_profile)
 print(f"Total fuel consumption: {results['total_kg']} kg")
 ```
+
+## Custom SFC curves
+
+By default, cetos estimates specific fuel consumption (SFC) using the IMO Fourth GHG Study 2020 model. You can instead supply your own SFC curve — for example, one measured on an engine test bed — and cetos will use it for the propulsion engines.
+
+Continuing from the Quick Start above:
+
+```python
+from cetos import SFCCurve
+
+# Build an SFC curve from measured points (g/kWh at part loads, the default unit)
+sfc_curve = SFCCurve.from_points(
+    [(0.25, 205), (0.50, 190), (0.75, 182), (0.85, 180), (1.00, 185)],
+    interpolation="pchip",  # smooth, shape-preserving; "linear" is the default
+)
+
+# Attach the curve to the vessel. Fuel estimates now use your curve for the
+# propulsion engines in place of the IMO model (auxiliary engines and steam
+# boilers are unaffected).
+vessel_data.propulsion_engine_sfc_curve = sfc_curve
+
+results = imo.estimate_fuel_consumption(vessel_data, voyage_profile)
+print(f"Total fuel consumption: {results['total_kg']} kg")
+```
+
+A curve can also be passed directly to `VesselData(...)` as the `propulsion_engine_sfc_curve` argument. Besides `SFCCurve.from_points`, two other constructors are available:
+
+- `SFCCurve.from_callable(fn, units="g/kWh")` — wrap any `load -> SFC` function
+- `SFCCurve.constant(value, units="g/kWh")` — a flat, load-independent SFC
+
+SFC values are interpreted as `g/kWh` by default; pass `units="kg/kWh"` if your data is already in `kg/kWh`.
 
 ## Modules
 

--- a/cetos/__init__.py
+++ b/cetos/__init__.py
@@ -1,9 +1,11 @@
 """cetos - Tools for analyzing vessel data."""
 
 from cetos.models import VesselData, VoyageLeg, VoyageProfile
+from cetos.sfc import SFCCurve
 
 __all__ = [
     "VesselData",
     "VoyageProfile",
     "VoyageLeg",
+    "SFCCurve",
 ]

--- a/cetos/imo.py
+++ b/cetos/imo.py
@@ -226,6 +226,41 @@ def estimate_specific_fuel_consumption(engine_load, engine_type, fuel_type, engi
     return sfc
 
 
+def estimate_propulsion_engine_sfc(vessel_data: VesselData, engine_load):
+    """Resolve the specific fuel consumption of a vessel's propulsion engine.
+
+    If the vessel has a custom SFC curve (``propulsion_engine_sfc_curve``), that
+    curve is evaluated and fully replaces the IMO model. Otherwise the IMO
+    Fourth GHG Study 2020 model is used (see
+    :func:`estimate_specific_fuel_consumption`).
+
+    Arguments:
+    ----------
+
+        vessel_data: VesselData
+            VesselData instance describing the vessel.
+
+        engine_load: float
+            Engine load as a fraction between 0.0 and 1.0.
+
+    Returns:
+    --------
+
+        float
+            Specific fuel consumption (kg/kWh).
+
+    """
+    curve = vessel_data.propulsion_engine_sfc_curve
+    if curve is not None:
+        return curve(engine_load)
+    return estimate_specific_fuel_consumption(
+        engine_load,
+        vessel_data.propulsion_engine_type,
+        vessel_data.propulsion_engine_fuel_type,
+        vessel_data.propulsion_engine_age,
+    )
+
+
 def estimate_auxiliary_power_demand(vessel_data: VesselData, operation_mode):
     """
     Estimate the auxiliary power demand.
@@ -692,17 +727,11 @@ def estimate_instantanous_fuel_consumption_of_propulsion_engines(
 
     installed_propulsion_power = calculate_installed_propulsion_power(vessel_data)
 
-    fuel_type = vessel_data.propulsion_engine_fuel_type
-    engine_age = vessel_data.propulsion_engine_age
-    engine_type = vessel_data.propulsion_engine_type
-
     load = estimate_propulsion_engine_load(speed, draft, vessel_data, delta_w=delta_w)
     if load < 0.07 and limit_7_percent:
         sfc = 0.0
     else:
-        sfc = estimate_specific_fuel_consumption(
-            load, engine_type, fuel_type, engine_age
-        )
+        sfc = estimate_propulsion_engine_sfc(vessel_data, load)
     return installed_propulsion_power * load * sfc
 
 

--- a/cetos/models.py
+++ b/cetos/models.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+from cetos.sfc import SFCCurve
 from cetos.utils import verify_range, verify_set
 
 # Validation constants
@@ -89,6 +90,10 @@ class VesselData:
     propulsion_engine_age: str  # One of ENGINE_AGES
     propulsion_engine_fuel_type: str  # One of FUEL_TYPES
 
+    # Optional custom SFC curve for the propulsion engine. When set, it
+    # overrides the IMO SFC model (see cetos.imo.estimate_propulsion_engine_sfc).
+    propulsion_engine_sfc_curve: Optional[SFCCurve] = None
+
     def __post_init__(self):
         """Validate vessel data."""
         verify_range("length_m", self.length_m, 5.0, 450.0)
@@ -121,6 +126,13 @@ class VesselData:
 
         if self.size is not None:
             verify_range("size", self.size, 0, 500_000)
+
+        if self.propulsion_engine_sfc_curve is not None and not isinstance(
+            self.propulsion_engine_sfc_curve, SFCCurve
+        ):
+            raise ValueError(
+                "'propulsion_engine_sfc_curve' must be an SFCCurve instance or None."
+            )
 
 
 @dataclass

--- a/cetos/sfc.py
+++ b/cetos/sfc.py
@@ -1,0 +1,273 @@
+"""
+User-supplied specific fuel consumption (SFC) curves.
+
+An SFC curve maps propulsion-engine load (a fraction between 0.0 and 1.0) to a
+specific fuel consumption in kg/kWh. By default cetos uses the IMO Fourth GHG
+Study 2020 model (see :func:`cetos.imo.estimate_specific_fuel_consumption`).
+This module lets a user supply their own measured or known curve instead, by
+attaching an :class:`SFCCurve` to ``VesselData.propulsion_engine_sfc_curve``.
+"""
+
+import math
+import numbers
+
+import numpy as np
+
+from cetos.utils import verify_range
+
+# Supported units for SFC input, with their conversion factor to kg/kWh.
+_SFC_UNITS = {
+    "g/kWh": 1e-3,
+    "kg/kWh": 1.0,
+}
+
+
+def _verify_positive_finite(name, value):
+    """Verify that a value is a finite, strictly positive number."""
+    if not isinstance(value, numbers.Real):
+        raise ValueError(f"'{name}' must be a number, got {value!r}.")
+    if not math.isfinite(value):
+        raise ValueError(f"'{name}' must be finite, got {value}.")
+    if value <= 0:
+        raise ValueError(f"'{name}' must be strictly positive, got {value}.")
+
+
+class SFCCurve:
+    """A specific fuel consumption curve: engine load -> SFC (kg/kWh).
+
+    Do not instantiate directly; use one of the factory class methods:
+
+        - :meth:`SFCCurve.from_points`: linear or shape-preserving cubic
+          interpolation of measured (load, SFC) points, e.g. from an engine
+          shop-test report.
+        - :meth:`SFCCurve.from_callable`: wrap an arbitrary load -> SFC
+          function.
+        - :meth:`SFCCurve.constant`: a load-independent SFC.
+
+    An :class:`SFCCurve` is callable: ``curve(engine_load)`` returns the SFC in
+    kg/kWh. Internally all values are stored in kg/kWh, matching the return
+    value of :func:`cetos.imo.estimate_specific_fuel_consumption`.
+    """
+
+    def __init__(self, _evaluate, _description):
+        # Internal constructor. Use the factory class methods instead.
+        self._evaluate = _evaluate
+        self._description = _description
+
+    @staticmethod
+    def _unit_factor(units):
+        """Return the multiplier that converts ``units`` to kg/kWh."""
+        if units not in _SFC_UNITS:
+            raise ValueError(
+                f"'units' must be one of {sorted(_SFC_UNITS)}, got {units!r}."
+            )
+        return _SFC_UNITS[units]
+
+    @classmethod
+    def from_points(
+        cls,
+        points,
+        *,
+        units="g/kWh",
+        interpolation="linear",
+        extrapolation="clamp",
+    ):
+        """Build a curve by interpolating measured points.
+
+        This is the typical case: engine datasheets and shop-test reports give
+        SFC at a handful of part loads (e.g. 25%, 50%, 75%, 85%, 100%). For a
+        faithful curve, supply points that capture its shape -- in particular
+        one near the 70-90% load minimum where the SFC bucket bottoms out.
+
+        Arguments:
+        ----------
+
+            points: iterable of (load, sfc)
+                At least two (engine_load, sfc) pairs. ``load`` is a fraction
+                between 0.0 and 1.0; ``sfc`` is expressed in ``units``. Points
+                are sorted by load automatically; duplicate loads are rejected.
+
+            units (optional): string
+                Units of the ``sfc`` values: 'g/kWh' (default) or 'kg/kWh'.
+
+            interpolation (optional): string
+                How to interpolate between the measured points:
+                    - 'linear' (default): piecewise-linear. Bounded and
+                      predictable, but its chords slightly overestimate a
+                      convex SFC curve between points.
+                    - 'pchip': shape-preserving piecewise cubic (monotone
+                      Hermite). Smooth and, unlike a plain cubic spline, free
+                      of overshoot. Best when the measured points are sparse.
+
+            extrapolation (optional): string
+                Behaviour for an engine load outside the measured range:
+                    - 'clamp' (default): hold the nearest endpoint value.
+                    - 'error': raise a ValueError.
+
+        Returns:
+        --------
+
+            SFCCurve
+        """
+        factor = cls._unit_factor(units)
+        if interpolation not in ("linear", "pchip"):
+            raise ValueError(
+                f"'interpolation' must be 'linear' or 'pchip', got {interpolation!r}."
+            )
+        if extrapolation not in ("clamp", "error"):
+            raise ValueError(
+                f"'extrapolation' must be 'clamp' or 'error', got {extrapolation!r}."
+            )
+
+        points = list(points)
+        if len(points) < 2:
+            raise ValueError("'from_points' requires at least 2 (load, sfc) points.")
+
+        loads = []
+        sfcs = []
+        for point in points:
+            try:
+                load, sfc = point
+            except (TypeError, ValueError) as err:
+                raise ValueError(
+                    f"Each point must be a (load, sfc) pair, got {point!r}."
+                ) from err
+            verify_range("load", load, 0.0, 1.0)
+            _verify_positive_finite("sfc", sfc)
+            loads.append(float(load))
+            sfcs.append(float(sfc) * factor)
+
+        order = np.argsort(loads)
+        loads = np.asarray(loads)[order]
+        sfcs = np.asarray(sfcs)[order]
+        if np.any(np.diff(loads) == 0):
+            raise ValueError("'from_points' received duplicate load values.")
+
+        lowest, highest = float(loads[0]), float(loads[-1])
+
+        if interpolation == "linear":
+
+            def _interpolate(engine_load):
+                return float(np.interp(engine_load, loads, sfcs))
+
+        else:
+            from scipy.interpolate import PchipInterpolator
+
+            _pchip = PchipInterpolator(loads, sfcs, extrapolate=False)
+
+            def _interpolate(engine_load):
+                return float(_pchip(engine_load))
+
+        def _evaluate(engine_load):
+            if not lowest <= engine_load <= highest:
+                if extrapolation == "error":
+                    raise ValueError(
+                        f"'engine_load' {engine_load} is outside the curve's "
+                        f"measured range [{lowest}, {highest}] and "
+                        f"extrapolation='error'."
+                    )
+                # 'clamp': hold the nearest endpoint value.
+                engine_load = min(max(engine_load, lowest), highest)
+            return _interpolate(engine_load)
+
+        description = (
+            f"from_points, {len(loads)} points, "
+            f"load {lowest:.2f}-{highest:.2f}, "
+            f"interpolation={interpolation!r}, extrapolation={extrapolation!r}"
+        )
+        return cls(_evaluate, description)
+
+    @classmethod
+    def from_callable(cls, fn, *, units="g/kWh"):
+        """Build a curve from an arbitrary user function.
+
+        The full-flexibility escape hatch. The function is sample-evaluated at
+        construction time to catch obvious errors early.
+
+        Arguments:
+        ----------
+
+            fn: callable
+                A function taking an engine load (fraction between 0.0 and 1.0)
+                and returning an SFC expressed in ``units``.
+
+            units (optional): string
+                Units of the value returned by ``fn``: 'g/kWh' (default) or
+                'kg/kWh'.
+
+        Returns:
+        --------
+
+            SFCCurve
+        """
+        factor = cls._unit_factor(units)
+        if not callable(fn):
+            raise ValueError(f"'from_callable' requires a callable, got {fn!r}.")
+
+        def _evaluate(engine_load):
+            sfc = fn(engine_load) * factor
+            _verify_positive_finite("sfc", sfc)
+            return float(sfc)
+
+        # Sample-evaluate to surface obvious errors at construction time.
+        for sample_load in (0.1, 0.5, 1.0):
+            try:
+                _evaluate(sample_load)
+            except ValueError:
+                raise
+            except Exception as err:  # noqa: BLE001 - re-raised as ValueError
+                raise ValueError(
+                    f"The callable raised {type(err).__name__} when evaluated "
+                    f"at load={sample_load}: {err}"
+                ) from err
+
+        name = getattr(fn, "__name__", repr(fn))
+        return cls(_evaluate, f"from_callable({name})")
+
+    @classmethod
+    def constant(cls, value, *, units="g/kWh"):
+        """Build a load-independent (flat) curve.
+
+        Arguments:
+        ----------
+
+            value: float
+                The SFC, expressed in ``units``.
+
+            units (optional): string
+                Units of ``value``: 'g/kWh' (default) or 'kg/kWh'.
+
+        Returns:
+        --------
+
+            SFCCurve
+        """
+        factor = cls._unit_factor(units)
+        _verify_positive_finite("value", value)
+        sfc = float(value) * factor
+
+        def _evaluate(_):
+            return sfc
+
+        return cls(_evaluate, f"constant({sfc:.5f} kg/kWh)")
+
+    def __call__(self, engine_load):
+        """Return the specific fuel consumption (kg/kWh) at ``engine_load``.
+
+        Arguments:
+        ----------
+
+            engine_load: float
+                Engine load as a fraction between 0.0 and 1.0.
+
+        Returns:
+        --------
+
+            float
+                Specific fuel consumption (kg/kWh).
+        """
+        verify_range("engine_load", engine_load, 0.0, 1.0)
+        return self._evaluate(engine_load)
+
+    def __repr__(self):
+        return f"SFCCurve({self._description})"

--- a/pinned_results.json
+++ b/pinned_results.json
@@ -9,6 +9,7 @@
         "propulsion_engine_age": "after_2000",
         "propulsion_engine_fuel_type": "MDO",
         "propulsion_engine_power_kw": 19874.343602077697,
+        "propulsion_engine_sfc_curve": null,
         "propulsion_engine_type": "SSD",
         "size": 149400.0,
         "type": "oil_tanker"
@@ -23,6 +24,7 @@
         "propulsion_engine_age": "after_2000",
         "propulsion_engine_fuel_type": "MDO",
         "propulsion_engine_power_kw": 81.24362828203402,
+        "propulsion_engine_sfc_curve": null,
         "propulsion_engine_type": "HSD",
         "size": 67.19999999999999,
         "type": "service-other"
@@ -37,6 +39,7 @@
         "propulsion_engine_age": "after_2000",
         "propulsion_engine_fuel_type": "MDO",
         "propulsion_engine_power_kw": 374.4310936077655,
+        "propulsion_engine_sfc_curve": null,
         "propulsion_engine_type": "HSD",
         "size": 441.0,
         "type": "miscellaneous-fishing"
@@ -51,6 +54,7 @@
         "propulsion_engine_age": "after_2000",
         "propulsion_engine_fuel_type": "MDO",
         "propulsion_engine_power_kw": 429.697010223062,
+        "propulsion_engine_sfc_curve": null,
         "propulsion_engine_type": "HSD",
         "size": 909.9999999999999,
         "type": "service-other"
@@ -65,6 +69,7 @@
         "propulsion_engine_age": "after_2000",
         "propulsion_engine_fuel_type": "MDO",
         "propulsion_engine_power_kw": 342.4869948609484,
+        "propulsion_engine_sfc_curve": null,
         "propulsion_engine_type": "MSD",
         "size": 418.72656,
         "type": "ferry-ropax"
@@ -79,6 +84,7 @@
         "propulsion_engine_age": "after_2000",
         "propulsion_engine_fuel_type": "MDO",
         "propulsion_engine_power_kw": 4153.162252003798,
+        "propulsion_engine_sfc_curve": null,
         "propulsion_engine_type": "MSD",
         "size": 16233.70663384615,
         "type": "ferry-ropax"
@@ -93,6 +99,7 @@
         "propulsion_engine_age": "after_2000",
         "propulsion_engine_fuel_type": "MDO",
         "propulsion_engine_power_kw": 4332.868134818988,
+        "propulsion_engine_sfc_curve": null,
         "propulsion_engine_type": "SSD",
         "size": 15395.624999999998,
         "type": "general_cargo"
@@ -107,6 +114,7 @@
         "propulsion_engine_age": "after_2000",
         "propulsion_engine_fuel_type": "MDO",
         "propulsion_engine_power_kw": 12031.936926164448,
+        "propulsion_engine_sfc_curve": null,
         "propulsion_engine_type": "SSD",
         "size": 71238.46153846153,
         "type": "general_cargo"
@@ -121,6 +129,7 @@
         "propulsion_engine_age": "after_2000",
         "propulsion_engine_fuel_type": "MDO",
         "propulsion_engine_power_kw": 8882.912889744446,
+        "propulsion_engine_sfc_curve": null,
         "propulsion_engine_type": "SSD",
         "size": 47808.0,
         "type": "oil_tanker"
@@ -1397,6 +1406,7 @@
             "propulsion_engine_age": "after_2000",
             "propulsion_engine_fuel_type": "MDO",
             "propulsion_engine_power_kw": 342.4869948609484,
+            "propulsion_engine_sfc_curve": null,
             "propulsion_engine_type": "MSD",
             "size": 418.72656,
             "type": "ferry-ropax"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 dynamic = ["version"]
-dependencies = ["numpy", "scikit-learn"]
+dependencies = ["numpy", "scikit-learn", "scipy"]
 
 [project.urls]
 Homepage = "https://github.com/RISE-Maritime/cetos"

--- a/tests/test_imo.py
+++ b/tests/test_imo.py
@@ -8,9 +8,11 @@ from cetos.imo import (
     estimate_fuel_consumption_of_propulsion_engines,
     estimate_instantaneous_fuel_consumption_of_auxiliary_systems,
     estimate_propulsion_engine_load,
+    estimate_propulsion_engine_sfc,
     estimate_specific_fuel_consumption,
 )
 from cetos.models import VesselData, VoyageLeg, VoyageProfile
+from cetos.sfc import SFCCurve
 
 DUMMY_VESSEL_DATA = VesselData(
     design_speed_kn=10,
@@ -188,4 +190,57 @@ def test_estimate_fuel_consumption_of_propulsion_engines():
     assert fc == approx(
         fc_all["manoeuvring"]["propulsion_engines_kg"]
         + fc_all["at_sea"]["propulsion_engines_kg"]
+    )
+
+
+def test_estimate_propulsion_engine_sfc():
+    # Without a custom curve, the resolver reproduces the IMO model exactly.
+    load = 0.6
+    expected_imo = estimate_specific_fuel_consumption(load, "MSD", "MDO", "after_2000")
+    assert estimate_propulsion_engine_sfc(DUMMY_VESSEL_DATA, load) == approx(
+        expected_imo
+    )
+
+    # With a custom curve, the resolver returns the curve's value.
+    vessel = replace(
+        DUMMY_VESSEL_DATA, propulsion_engine_sfc_curve=SFCCurve.constant(200)
+    )
+    assert estimate_propulsion_engine_sfc(vessel, load) == approx(0.200)
+
+
+def test_custom_sfc_curve_changes_propulsion_fuel_consumption():
+    # A custom curve overrides the IMO SFC model for the propulsion engines.
+    fc_imo = estimate_fuel_consumption(DUMMY_VESSEL_DATA, DUMMY_VOYAGE_PROFILE)
+
+    # A deliberately high flat SFC must increase propulsion fuel consumption.
+    vessel_high = replace(
+        DUMMY_VESSEL_DATA, propulsion_engine_sfc_curve=SFCCurve.constant(500)
+    )
+    fc_high = estimate_fuel_consumption(vessel_high, DUMMY_VOYAGE_PROFILE)
+
+    assert (
+        fc_high["at_sea"]["propulsion_engines_kg"]
+        > fc_imo["at_sea"]["propulsion_engines_kg"]
+    )
+    # Auxiliary engines still use the IMO model, so they are unaffected.
+    assert fc_high["at_sea"]["auxiliary_engines_kg"] == approx(
+        fc_imo["at_sea"]["auxiliary_engines_kg"]
+    )
+
+
+def test_custom_curve_matching_imo_reproduces_fuel_consumption():
+    # A custom curve that mirrors the IMO model reproduces the IMO result.
+    imo_curve = SFCCurve.from_callable(
+        lambda load: estimate_specific_fuel_consumption(
+            load, "MSD", "MDO", "after_2000"
+        ),
+        units="kg/kWh",
+    )
+    vessel = replace(DUMMY_VESSEL_DATA, propulsion_engine_sfc_curve=imo_curve)
+
+    fc_custom = estimate_fuel_consumption(vessel, DUMMY_VOYAGE_PROFILE)
+    fc_imo = estimate_fuel_consumption(DUMMY_VESSEL_DATA, DUMMY_VOYAGE_PROFILE)
+
+    assert fc_custom["at_sea"]["propulsion_engines_kg"] == approx(
+        fc_imo["at_sea"]["propulsion_engines_kg"]
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 from pytest import raises
 
 from cetos.models import VesselData, VoyageLeg, VoyageProfile
+from cetos.sfc import SFCCurve
 
 VALID_VESSEL_DATA = VesselData(
     length_m=100,
@@ -80,6 +81,21 @@ def test_vessel_data_invalid_number_of_engines():
     with raises(ValueError) as info:
         replace(VALID_VESSEL_DATA, number_of_propulsion_engines=5)
     assert "number_of_propulsion_engines" in str(info)
+
+
+def test_vessel_data_invalid_sfc_curve():
+    """Test that a non-SFCCurve propulsion SFC curve raises ValueError."""
+    with raises(ValueError) as info:
+        replace(VALID_VESSEL_DATA, propulsion_engine_sfc_curve=lambda load: 0.18)
+    assert "propulsion_engine_sfc_curve" in str(info)
+
+
+def test_vessel_data_accepts_sfc_curve():
+    """Test that an SFCCurve is accepted as the propulsion SFC curve."""
+    vessel = replace(
+        VALID_VESSEL_DATA, propulsion_engine_sfc_curve=SFCCurve.constant(190)
+    )
+    assert vessel.propulsion_engine_sfc_curve is not None
 
 
 def test_voyage_leg_valid_creation():

--- a/tests/test_sfc.py
+++ b/tests/test_sfc.py
@@ -1,0 +1,191 @@
+from pytest import approx, raises
+
+from cetos.sfc import SFCCurve
+
+
+def test_from_points_interpolation():
+    """Piecewise-linear interpolation between measured points (g/kWh default)."""
+    curve = SFCCurve.from_points([(0.5, 200), (1.0, 180)])
+    assert curve(0.5) == approx(0.200)
+    assert curve(1.0) == approx(0.180)
+    # Linear interpolation at the midpoint.
+    assert curve(0.75) == approx(0.190)
+
+
+def test_from_points_units_kg_per_kwh():
+    """Points can be supplied directly in kg/kWh."""
+    curve = SFCCurve.from_points([(0.5, 0.2), (1.0, 0.18)], units="kg/kWh")
+    assert curve(0.5) == approx(0.2)
+    assert curve(1.0) == approx(0.18)
+
+
+def test_from_points_unsorted_input_is_sorted():
+    """Points given out of order are sorted by load."""
+    curve = SFCCurve.from_points([(1.0, 180), (0.5, 200), (0.75, 185)])
+    assert curve(0.5) == approx(0.200)
+    assert curve(0.75) == approx(0.185)
+    assert curve(1.0) == approx(0.180)
+
+
+def test_from_points_clamps_outside_range_by_default():
+    """Loads outside the measured range clamp to the nearest endpoint."""
+    curve = SFCCurve.from_points([(0.5, 200), (1.0, 180)])
+    assert curve(0.1) == approx(0.200)
+
+
+def test_from_points_extrapolation_error():
+    """extrapolation='error' rejects loads outside the measured range."""
+    curve = SFCCurve.from_points([(0.5, 200), (1.0, 180)], extrapolation="error")
+    with raises(ValueError) as info:
+        curve(0.1)
+    assert "outside" in str(info)
+    # Loads within the measured range still work.
+    assert curve(0.75) == approx(0.190)
+
+
+def test_from_points_requires_at_least_two_points():
+    with raises(ValueError) as info:
+        SFCCurve.from_points([(0.5, 200)])
+    assert "at least 2" in str(info)
+
+
+def test_from_points_rejects_duplicate_loads():
+    with raises(ValueError) as info:
+        SFCCurve.from_points([(0.5, 200), (0.5, 190)])
+    assert "duplicate" in str(info)
+
+
+def test_from_points_rejects_load_out_of_range():
+    with raises(ValueError) as info:
+        SFCCurve.from_points([(0.5, 200), (1.5, 180)])
+    assert "load" in str(info)
+
+
+def test_from_points_rejects_non_positive_sfc():
+    with raises(ValueError) as info:
+        SFCCurve.from_points([(0.5, 200), (1.0, -1)])
+    assert "sfc" in str(info)
+
+
+def test_from_points_pchip_passes_through_points():
+    """PCHIP interpolation passes exactly through the measured points."""
+    points = [(0.25, 210), (0.5, 190), (0.75, 180), (1.0, 185)]
+    curve = SFCCurve.from_points(points, interpolation="pchip")
+    for load, sfc in points:
+        assert curve(load) == approx(sfc / 1000.0)
+
+
+def test_from_points_pchip_differs_from_linear_between_points():
+    """PCHIP and linear interpolation generally disagree between points."""
+    points = [(0.25, 210), (0.5, 190), (0.75, 180), (1.0, 185)]
+    pchip = SFCCurve.from_points(points, interpolation="pchip")
+    linear = SFCCurve.from_points(points, interpolation="linear")
+    assert pchip(0.6) != approx(linear(0.6))
+
+
+def test_from_points_pchip_stays_within_data_range():
+    """PCHIP is shape-preserving: it does not overshoot the data range."""
+    points = [(0.25, 210), (0.5, 190), (0.75, 180), (1.0, 185)]
+    curve = SFCCurve.from_points(points, interpolation="pchip")
+    for i in range(101):
+        load = 0.25 + 0.75 * i / 100
+        assert 0.180 - 1e-9 <= curve(load) <= 0.210 + 1e-9
+
+
+def test_from_points_pchip_clamps_outside_range():
+    """PCHIP curves clamp to the endpoint value outside the measured range."""
+    curve = SFCCurve.from_points(
+        [(0.5, 200), (0.75, 185), (1.0, 190)], interpolation="pchip"
+    )
+    assert curve(0.1) == approx(0.200)
+
+
+def test_from_points_pchip_extrapolation_error():
+    curve = SFCCurve.from_points(
+        [(0.5, 200), (0.75, 185), (1.0, 190)],
+        interpolation="pchip",
+        extrapolation="error",
+    )
+    with raises(ValueError) as info:
+        curve(0.1)
+    assert "outside" in str(info)
+
+
+def test_from_points_rejects_unknown_interpolation():
+    with raises(ValueError) as info:
+        SFCCurve.from_points([(0.5, 200), (1.0, 180)], interpolation="cubic")
+    assert "interpolation" in str(info)
+
+
+def test_from_callable():
+    curve = SFCCurve.from_callable(lambda _load: 180.0)
+    assert curve(0.5) == approx(0.180)
+
+
+def test_from_callable_units_kg_per_kwh():
+    curve = SFCCurve.from_callable(lambda _load: 0.18, units="kg/kWh")
+    assert curve(0.5) == approx(0.18)
+
+
+def test_from_callable_rejects_non_callable():
+    with raises(ValueError) as info:
+        SFCCurve.from_callable(123)
+    assert "callable" in str(info)
+
+
+def test_from_callable_rejects_negative_return():
+    """A callable returning a non-positive SFC fails at construction time."""
+    with raises(ValueError) as info:
+        SFCCurve.from_callable(lambda _load: -5.0)
+    assert "sfc" in str(info)
+
+
+def test_from_callable_surfaces_callable_errors():
+    """An error raised by the callable surfaces as a ValueError at build time."""
+
+    def bad(_load):
+        raise RuntimeError("boom")
+
+    with raises(ValueError) as info:
+        SFCCurve.from_callable(bad)
+    assert "RuntimeError" in str(info)
+
+
+def test_constant():
+    curve = SFCCurve.constant(190)
+    assert curve(0.1) == approx(0.190)
+    assert curve(0.5) == approx(0.190)
+    assert curve(1.0) == approx(0.190)
+
+
+def test_constant_rejects_non_positive():
+    with raises(ValueError) as info:
+        SFCCurve.constant(0)
+    assert "value" in str(info)
+
+
+def test_rejects_unknown_units():
+    with raises(ValueError) as info:
+        SFCCurve.from_points([(0.5, 200), (1.0, 180)], units="lb/hph")
+    assert "units" in str(info)
+
+
+def test_rejects_unknown_extrapolation():
+    with raises(ValueError) as info:
+        SFCCurve.from_points([(0.5, 200), (1.0, 180)], extrapolation="quadratic")
+    assert "extrapolation" in str(info)
+
+
+def test_call_rejects_load_out_of_range():
+    """Evaluating a curve outside [0, 1] raises a ValueError."""
+    curve = SFCCurve.from_points([(0.5, 200), (1.0, 180)])
+    with raises(ValueError) as info:
+        curve(1.5)
+    assert "engine_load" in str(info)
+    with raises(ValueError) as info:
+        curve(-0.1)
+    assert "engine_load" in str(info)
+
+
+def test_repr():
+    assert "SFCCurve" in repr(SFCCurve.constant(190))


### PR DESCRIPTION
Users can now override the IMO Fourth GHG Study 2020 specific fuel consumption (SFC) model with their own measured curve.

- New cetos.sfc.SFCCurve: a validated load -> SFC (kg/kWh) mapping with three factories: from_points (linear or shape-preserving PCHIP interpolation), from_callable, and constant. Units default to g/kWh.
- VesselData gains an optional propulsion_engine_sfc_curve field; when set it overrides the IMO model for the propulsion engines (auxiliary engines and steam boilers are unaffected).
- New cetos.imo.estimate_propulsion_engine_sfc resolver; the IMO model and estimate_specific_fuel_consumption are unchanged.
- Declare scipy explicitly (used for PCHIP interpolation).
- Regenerate pinned_results.json for the new (null) VesselData field; no computed values changed.
- Fix the README Quick Start example, whose voyage legs used a draft outside the valid range for the example vessel.